### PR TITLE
Remove peso sign from price display

### DIFF
--- a/lib/screens/listing_screen.dart
+++ b/lib/screens/listing_screen.dart
@@ -1722,7 +1722,7 @@ class _ListingDetailsModal extends StatelessWidget {
                           ),
                           const SizedBox(width: 16),
                           Text(
-                            isFree ? 'FREE' : '₱$price',
+                            isFree ? 'FREE' : '$price',
                             style: TextStyle(
                               fontSize: 32,
                               fontWeight: FontWeight.bold,


### PR DESCRIPTION
Updated the price display in the listing details modal to show the price without the peso sign. This ensures consistency with other parts of the UI or may be required for formatting reasons.